### PR TITLE
[Sync] Update project files from source repository (c33a09d)

### DIFF
--- a/.github/actions/setup-go-with-cache/action.yml
+++ b/.github/actions/setup-go-with-cache/action.yml
@@ -442,7 +442,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 🏗️ Set up Go
       id: setup-go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: false # we handle caches ourselves

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -49,7 +49,14 @@ MAGE_X_CI_SKIP_STEP_SUMMARY=false
 # ================================================================================================
 
 MAGE_X_AUTO_DISCOVER_BUILD_TAGS=true
-MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE=race,custom
+# Exclude Go's reserved, environment-satisfied build constraints from discovery:
+# all GOOS + GOARCH names plus toolchain/feature tokens. These are selected by
+# GOOS/GOARCH/build flags, never by -tags. If discovered and passed as -tags,
+# e.g. -tags=darwin from a //go:build darwin file, a linux runner satisfies BOTH
+# GOOS variants of stdlib internal/goos -> "GOOS redeclared" -> build fails ->
+# no coverage.txt -> Codecov "Verify coverage file" fails. Custom tags
+# (integration, e2e) are still discovered; go1.NN version tags are skipped by mage-x.
+MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE=race,custom,msan,asan,cgo,gc,gccgo,boringcrypto,unix,aix,android,darwin,dragonfly,freebsd,hurd,illumos,ios,js,linux,nacl,netbsd,openbsd,plan9,solaris,wasip1,windows,zos,386,amd64,amd64p32,arm,armbe,arm64,arm64be,loong64,mips,mipsle,mips64,mips64le,mips64p32,mips64p32le,ppc,ppc64,ppc64le,riscv,riscv64,s390,s390x,sparc,sparc64,wasm
 # Run all discovered tags in a single test pass (fast). Set to false in a
 # project env file to fall back to one separate pass per tag.
 MAGE_X_AUTO_DISCOVER_BUILD_TAGS_COMBINE=true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated `actions/setup-go` from v6.5.0 (commit `924ae3a`) to v7.0.0 (commit `b7ad1da`) in `.github/actions/setup-go-with-cache/action.yml`
* Updated `github/codeql-action/init`, `github/codeql-action/autobuild`, and `github/codeql-action/analyze` from v4.37.0 (commit `99df26d`) to v4.37.1 (commit `7188fc3`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/upload-sarif` from v4.37.0 (commit `99df26d`) to v4.37.1 (commit `7188fc3`) in `.github/workflows/scorecard.yml`
* Expanded `MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE` in `.github/env/10-mage-x.env` to exclude all Go reserved build constraints (GOOS values: `aix`, `android`, `darwin`, `dragonfly`, `freebsd`, `hurd`, `illumos`, `ios`, `js`, `linux`, `nacl`, `netbsd`, `openbsd`, `plan9`, `solaris`, `wasip1`, `windows`, `zos`; GOARCH values: `386`, `amd64`, `amd64p32`, `arm`, `armbe`, `arm64`, `arm64be`, `loong64`, `mips`, `mipsle`, `mips64`, `mips64le`, `mips64p32`, `mips64p32le`, `ppc`, `ppc64`, `ppc64le`, `riscv`, `riscv64`, `s390`, `s390x`, `sparc`, `sparc64`, `wasm`; and toolchain/feature tokens: `msan`, `asan`, `cgo`, `gc`, `gccgo`, `boringcrypto`, `unix`)
* Added detailed inline comment explaining the exclusion prevents "GOOS redeclared" build failures when platform-specific build tags are incorrectly passed via `-tags` instead of being satisfied by environment variables

## Why It Was Necessary

* Updating GitHub Actions to their latest versions ensures security patches and bug fixes are applied
* Excluding Go's reserved build constraints from auto-discovery prevents build failures caused by passing environment-satisfied constraints (like `darwin`, `linux`) as explicit `-tags`, which leads to "GOOS redeclared" errors in stdlib packages
* The expanded exclusion list fixes Codecov verification failures that occurred when coverage.txt files weren't generated due to build errors from conflicting GOOS/GOARCH declarations

## Testing Performed

* GitHub Actions updates should be validated by verifying CI workflows complete successfully with the new action versions
* The `MAGE_X_AUTO_DISCOVER_BUILD_TAGS_EXCLUDE` change should be tested by running builds on different platforms (Linux, macOS, Windows) to confirm no "GOOS redeclared" errors occur
* Verify that coverage.txt files are successfully generated and uploaded to Codecov after the mage-x configuration change

## Impact / Risk

* **Low Risk**: GitHub Actions version bumps are patch-level updates (v4.37.0 → v4.37.1) and minor version update (v6.5.0 → v7.0.0) for setup-go, which typically maintain backward compatibility
* **Positive Impact**: Fixes build failures and Codecov verification issues caused by incorrect handling of platform-specific build tags
* **Build Behavior Change**: Custom integration/e2e tags continue to be auto-discovered, but reserved Go build constraints are now properly excluded from `-tags` flags

<!-- go-broadcast-metadata
group:
  id: third-party-sdks
  name: third-party-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: c33a09d9878957d0616cdfdc710662f703bea067
  target_repo: mrz1836/go-drift
  sync_commit: 6a877f8910da0d8ac945d687cbf9685a44e4e0b1
  sync_time: 2026-07-18T10:58:13-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 283
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1373
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 696
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 448
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 409
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1550
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 2
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1823
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 763
performance:
  total_files: 103
-->
